### PR TITLE
[Hotfix] Spring Security OAuth2 기본 로그인 화면 제거

### DIFF
--- a/src/main/java/com/pullanner/global/api/ApiResponseCode.java
+++ b/src/main/java/com/pullanner/global/api/ApiResponseCode.java
@@ -9,7 +9,7 @@ public enum ApiResponseCode {
 
     OAUTH2_LOGIN_FAIL("A02", 401, "로그인이 실패했습니다."),
     TOKEN_INVALID("A03", 403, "유효하지 않은 토큰입니다."),
-    TOKEN_HACKED("A04", 401, "토큰 도용이 의심됩니다."),
+    TOKEN_HACKED("A04", 401, "계정이 도용된 것으로 의심됩니다."),
     TOKEN_REFRESHED("A05", 200, "액세스 토큰이 재발급되었습니다."),
 
     USER_NOT_FOUND("U01", 404, "존재하지 않는 회원입니다."),

--- a/src/main/java/com/pullanner/global/auth/oauth2/handler/DefaultOAuth2LoginPageHandler.java
+++ b/src/main/java/com/pullanner/global/auth/oauth2/handler/DefaultOAuth2LoginPageHandler.java
@@ -1,0 +1,13 @@
+package com.pullanner.global.auth.oauth2.handler;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class DefaultOAuth2LoginPageHandler {
+
+    @GetMapping("/login/default")
+    public String defaultOAuth2LoginPage() {
+        return "redirect:/";
+    }
+}

--- a/src/main/java/com/pullanner/global/config/SecurityConfig.java
+++ b/src/main/java/com/pullanner/global/config/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
             .sessionCreationPolicy(SessionCreationPolicy.STATELESS) // 세션 기반이 아님을 선언
         .and()
             .oauth2Login() // OAuth2  로그인 설정 시작점
+            .loginPage("/login/default")
             .userInfoEndpoint() // OAuth2 로그인 성공 이후 사용자 정보를 가져올 때 설정 담당
             .userService(customOAuth2UserService)
         .and()


### PR DESCRIPTION
## 👨‍💻 작업 내용

+ 당초 `/login` 으로 서버에 요청 시 Spring Security 에서 제공하는 OAuth2 기본 로그인 화면이 보여지는 것을 제거

## 🔎 참고 사항

+ 없음
