### PR TITLE
[Feature/user] 사용자 닉네임 글자수 제약 수정

### DIFF
--- a/src/main/java/com/pullanner/domain/user/controller/UserController.java
+++ b/src/main/java/com/pullanner/domain/user/controller/UserController.java
@@ -20,8 +20,8 @@ import static com.pullanner.global.api.ApiUtil.getResponseEntity;
 @RestController
 public class UserController {
 
-    private static final int NICKNAME_MIN_LENGTH = 6;
-    private static final int NICKNAME_MAX_LENGTH = 15;
+    private static final int NICKNAME_MIN_LENGTH = 2;
+    private static final int NICKNAME_MAX_LENGTH = 8;
 
     private final UserService userService;
 

--- a/src/main/java/com/pullanner/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/pullanner/domain/user/dto/UserResponse.java
@@ -9,7 +9,7 @@ public class UserResponse {
 
     private Long userId;
     private String name;
-    private String nickName;
+    private String nickname;
     private String email;
     private String profileImage;
     private String oauthProvider;
@@ -17,11 +17,11 @@ public class UserResponse {
     private Integer journalCount;
 
     @Builder
-    private UserResponse(Long userId, String name, String nickName, String email,
+    private UserResponse(Long userId, String name, String nickname, String email,
         String profileImage, String oauthProvider) {
         this.userId = userId;
         this.name = name;
-        this.nickName = nickName;
+        this.nickname = nickname;
         this.email = email;
         this.profileImage = profileImage;
         this.oauthProvider = oauthProvider;
@@ -31,7 +31,7 @@ public class UserResponse {
         return UserResponse.builder()
             .userId(user.getId())
             .name(user.getName())
-            .nickName(user.getNickName())
+            .nickname(user.getNickName())
             .email(user.getEmail())
             .profileImage(user.getPicture())
             .oauthProvider(user.getProvider().name())


### PR DESCRIPTION
## 👨‍💻 작업 내용

+ 기존 사용자 닉네임 글자수가 최소 6, 최대 15 인 부분을 최소 2, 최대 8 로 수정

## 🔎 참고 사항

+ 사용자 정보 조회 데이터 필드 中 nickName 이름을 nickname 으로 수정
